### PR TITLE
[WRITER] artifactory.{prod,internal} migration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ releaseCrossBuild := false
 
 updateOptions := updateOptions.value.withGigahorse(false)
 
-publishTo := Some("Artifactory Realm" at "http://artifactory.prod.livongo.com/artifactory/plugins-release-local")
+publishTo := Some("Artifactory Realm" at "https://artifactory.internal.livongo.com/artifactory/plugins-release-local")
 credentials += Credentials("Artifactory Realm", "artifactory.prod.livongo.com", "admin", "<REDACTED>>")
 
 pomExtra := {


### PR DESCRIPTION
Update artifactory.prod references to read from artifactory.internal instead. The repositories on artifactory.prod are being replicated over to artifactory.internal and readers should be able to find what they need there.